### PR TITLE
cleanup temp file on document render exception

### DIFF
--- a/src/main/java/com/spraed/flyingsaucer/PDFGenerator.java
+++ b/src/main/java/com/spraed/flyingsaucer/PDFGenerator.java
@@ -105,20 +105,24 @@ public class PDFGenerator {
 			htmlInputStream.close();
 			htmlOutputStream.close();
 
-			// render pdf from tidy html
-			renderer.setDocument(htmlOutputFile);
-			renderer.layout();
+			try {
+				// render pdf from tidy html
+				renderer.setDocument(htmlOutputFile);
+				renderer.layout();
 
-			// check if pdf has to be created, iterate index afterwards
-			if (index == 0) {
-				renderer.createPDF(os, false);
-			} else {
-				renderer.writeNextDocument();
+				// check if pdf has to be created, iterate index afterwards
+				if (index == 0) {
+					renderer.createPDF(os, false);
+				} else {
+					renderer.writeNextDocument();
+				}
+				index++;
 			}
-			index++;
 
-			// delete html output file
-			htmlOutputFile.delete();
+			finally {
+				// delete html output file
+				htmlOutputFile.delete();
+			}
 		}
 
 		renderer.finishPDF();


### PR DESCRIPTION
if the html is still not valid after tidy then an exception can be thrown by iText.  this leaves a temporary file on disk whose name is not discoverable.

this always cleans up the temp file.
